### PR TITLE
Add ban-types rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.vscode
+.idea
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3 (March 30, 2020)
+
+- Add `Error` and `ApolloError` to `@typescript-eslint/ban-types` rule
+
 ## 0.5.2 (January 9, 2020)
 
 - Add `varsIgnorePattern` to `@typescript-eslint/no-unused-vars` rule

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const neoErrorRuleMessage = 'User neo errors instead';
+
 module.exports = {
   extends: [
     'eslint:recommended',
@@ -40,7 +42,16 @@ module.exports = {
         '@typescript-eslint/explicit-function-return-type': 'error',
         '@typescript-eslint/no-array-constructor': 'warn',
         '@typescript-eslint/no-namespace': 'error',
-        '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }]
+        '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
+        '@typescript-eslint/ban-types': [
+          'error',
+          {
+            'types': {
+              'Error': neoErrorRuleMessage,
+              'ApolloError': neoErrorRuleMessage
+            }
+          }
+        ]
         // enable this once typescript-eslint 2.9.0 is released
         // '@typescript-eslint/prefer-optional-chain': 'warn'
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
         '@typescript-eslint/no-namespace': 'error',
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
         '@typescript-eslint/ban-types': [
-          'error',
+          'warn',
           {
             'types': {
               'Error': neoErrorRuleMessage,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neo",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Official Neo Financial ESLint configuration",
   "main": "index.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",


### PR DESCRIPTION
We're trying to educate everyone to use neo errors, it might be useful adding a lint rule for that so that we get warned if we use the potentially wrong error types.

**Reference:** https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md