### PR TITLE
Add no-floating-promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0 (January 18, 2021)
+
+- Add `no-floating-promises` to config-backend-next
+
 ## 0.6.1 (November 22, 2020)
 
 - Disable `no-null` rule in base config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0 (January 18, 2021)
+## 0.6.2 (January 18, 2021)
 
 - Add `no-floating-promises` to config-backend-next
 

--- a/config-base-next.js
+++ b/config-base-next.js
@@ -11,21 +11,21 @@ module.exports = {
             checkArrowFunctions: true,
             checkFunctionDeclarations: true,
             checkFunctionExpressions: true,
-            checkMethodDeclarations: true
-          }
+            checkMethodDeclarations: true,
+          },
         ],
         '@typescript-eslint/require-await': 'error',
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/return-await': 'error',
 
-        'unicorn/no-null': 'warn'
-      }
+        'unicorn/no-null': 'warn',
+      },
     },
     {
       files: ['**/test/**/*'],
       rules: {
-        'unicorn/no-null': 'off'
-      }
-    }
-  ]
+        'unicorn/no-null': 'off',
+      },
+    },
+  ],
 };

--- a/config-base-next.js
+++ b/config-base-next.js
@@ -11,20 +11,21 @@ module.exports = {
             checkArrowFunctions: true,
             checkFunctionDeclarations: true,
             checkFunctionExpressions: true,
-            checkMethodDeclarations: true,
-          },
+            checkMethodDeclarations: true
+          }
         ],
         '@typescript-eslint/require-await': 'error',
+        '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/return-await': 'error',
 
-        'unicorn/no-null': 'warn',
-      },
+        'unicorn/no-null': 'warn'
+      }
     },
     {
       files: ['**/test/**/*'],
       rules: {
-        'unicorn/no-null': 'off',
-      },
-    },
-  ],
+        'unicorn/no-null': 'off'
+      }
+    }
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neo",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Official Neo Financial ESLint configuration",
   "main": "index.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neo",
-  "version": "0.7.0",
+  "version": "0.6.2",
   "description": "Official Neo Financial ESLint configuration",
   "main": "index.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",


### PR DESCRIPTION
### Description
Updating Neo's `next` config to try out `no-floating-promises`.
This requires

### Usage
Example minimal`.eslintrc` to use this.
```json
{
  "extends": "eslint-config-neo/config-backend-next",
  "parserOptions": {
    "project": "./tsconfig.json"
  }
}
```