### PR TITLE
SC-56621: Remove no "I" prefix rule from eslint config

### DIFF
--- a/config-base-next.js
+++ b/config-base-next.js
@@ -11,14 +11,14 @@ module.exports = {
             checkArrowFunctions: true,
             checkFunctionDeclarations: true,
             checkFunctionExpressions: true,
-            checkMethodDeclarations: true,
-          },
+            checkMethodDeclarations: true
+          }
         ],
         '@typescript-eslint/require-await': 'error',
         '@typescript-eslint/return-await': 'error',
-
-        'unicorn/no-null': 'warn',
-      },
-    },
-  ],
+        '@typescript-eslint/interface-name-prefix': 'off',
+        'unicorn/no-null': 'warn'
+      }
+    }
+  ]
 };


### PR DESCRIPTION
With us moving to relying on abstractions over concrete implementations on a lot of projects this rule starts to become quite the hassle to abide by and you find yourself trying to come up with another name for no real gain aside from making this rule happy.