### PR TITLE
Remove no I prefix rule from eslint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.3 (January 25, 2022)
+
+- Disable `@typescript-eslint/interface-name-prefix` rule
+
 ## 0.6.2 (January 29, 2021)
 
 - Disable `no-useless-undefined` rule in tests

--- a/config-backend.js
+++ b/config-backend.js
@@ -2,9 +2,10 @@ module.exports = {
   extends: ['./config-base.js'],
   env: {
     node: true,
-    mongo: true,
+    mongo: true
   },
   rules: {
     'node/no-unpublished-require': 'warn',
-  },
+    '@typescript-eslint/interface-name-prefix': 'off'
+  }
 };

--- a/config-backend.js
+++ b/config-backend.js
@@ -2,10 +2,10 @@ module.exports = {
   extends: ['./config-base.js'],
   env: {
     node: true,
-    mongo: true
+    mongo: true,
   },
   rules: {
     'node/no-unpublished-require': 'warn',
-    '@typescript-eslint/interface-name-prefix': 'off'
+    '@typescript-eslint/interface-name-prefix': 'off',
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neo",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Official Neo Financial ESLint configuration",
   "main": "index.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",


### PR DESCRIPTION
With us moving to relying on abstractions over concrete implementations on a lot of projects this rule starts to become quite the hassle to abide by and you find yourself trying to come up with another name for no real gain aside from making this rule happy.