### PR TITLE
BAASW-000 add rule for curly braces as per Neo style guide

### DIFF
--- a/config-base.js
+++ b/config-base.js
@@ -58,7 +58,7 @@ module.exports = {
     },
   ],
   rules: {
-    curly: ['all'],
+    curly: 'error',
     eqeqeq: ['error', 'smart'],
     'func-names': ['warn', 'as-needed'],
     'no-bitwise': 'warn',

--- a/config-base.js
+++ b/config-base.js
@@ -58,6 +58,7 @@ module.exports = {
     },
   ],
   rules: {
+    curly: ['all'],
     eqeqeq: ['error', 'smart'],
     'func-names': ['warn', 'as-needed'],
     'no-bitwise': 'warn',


### PR DESCRIPTION
This patch aims to remove the need for reviewing shorthand `if` conditions. I've encountered this in reviews quite a few times and decided that it fits in a linter given our [style guide](https://neofinancial.getoutline.com/doc/style-guide-BeLjv14vUi) makes mention of [_always bracing `if` statements_](https://neofinancial.getoutline.com/doc/style-guide-BeLjv14vUi#h-always-brace-if-statements).

The way I have done this is using [the _curly_ ESLint rule](https://eslint.org/docs/latest/rules/curly) set as `error`.

### Example

Writing code like the following

```ts
if (vimIsGreat) return true
```

Will emit the following error from ESLint

```
/Users/jorb/Code/neo/prequalification-service/src/domain/providers/jwt-validation/jwt-validation.provider.adapter.ts
  13:15  error    Expected { after 'if' condition  curly

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

Prompting the dev to write

```ts
if (vimIsGreat) {
    return true
}