### PR TITLE
fix: apply same no-unused-vars rule from ts-eslint to autofix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.11.0 (April, 9, 2024)
+## 0.11.1 (April 21, 2024)
+- fixes `autofix/no-unused-vars` rule for no-unused-vars where var matches `^_+`
+- removes `autofix/no-unused-vars` check specifically in migrations directory
+
+## 0.11.0 (April 9, 2024)
 - adds `eslint-plugin-autofix` package
 - adds `autofix/no-unused-vars` and `autofix/sort-imports` both as warning
 - This changes allows eslint to remove unused imports and to sort the imports in the natural order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## 0.11.1 (April 21, 2024)
-- fixes `autofix/no-unused-vars` rule for no-unused-vars where var matches `^_+`
-- removes `autofix/no-unused-vars` check specifically in migrations directory
+- fixes `autofix/no-unused-vars` rule to match existing rules from `@typescript-eslint/no-unused-vars` 
 
 ## 0.11.0 (April 9, 2024)
 - adds `eslint-plugin-autofix` package

--- a/config-backend.js
+++ b/config-backend.js
@@ -134,6 +134,7 @@ module.exports = {
       files: ['**/migrations/**/*'],
       rules: {
         '@typescript-eslint/no-unused-vars': 'off',
+        'autofix/no-unused-vars': 'off',
         'import/no-extraneous-dependencies': 'off',
         'no-console': 'off',
       },

--- a/config-base.js
+++ b/config-base.js
@@ -49,6 +49,7 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': ['error', { ignoreIIFE: true }],
         '@typescript-eslint/no-namespace': 'error',
         '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
+        'autofix/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
         '@typescript-eslint/no-use-before-define': ['error', { typedefs: false, enums: false }],
         '@typescript-eslint/prefer-optional-chain': 'warn',
         'unicorn/no-null': 'off',
@@ -177,7 +178,7 @@ module.exports = {
       },
     ],
     'import/newline-after-import': 'warn',
-    'autofix/no-unused-vars': 'warn',
+    'autofix/no-unused-vars': ['warn', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
     'autofix/sort-imports': ['warn', { ignoreCase: true, ignoreDeclarationSort: true }],
   },
 };

--- a/config-base.js
+++ b/config-base.js
@@ -178,6 +178,5 @@ module.exports = {
     ],
     'import/newline-after-import': 'warn',
     'autofix/sort-imports': ['warn', { ignoreCase: true, ignoreDeclarationSort: true }],
-    'autofix/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
   },
 };

--- a/config-base.js
+++ b/config-base.js
@@ -118,7 +118,6 @@ module.exports = {
         ignores: ['modules'],
       },
     ],
-
     'unicorn/catch-error-name': 'off',
     'unicorn/consistent-function-scoping': 'off',
     'unicorn/expiring-todo-comments': [
@@ -178,7 +177,7 @@ module.exports = {
       },
     ],
     'import/newline-after-import': 'warn',
-    'autofix/no-unused-vars': ['warn', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
     'autofix/sort-imports': ['warn', { ignoreCase: true, ignoreDeclarationSort: true }],
+    'autofix/no-unused-vars': ['error', { argsIgnorePattern: '^_+', varsIgnorePattern: '^_+' }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-neo",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-neo",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-neo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Official Neo Financial ESLint configuration",
   "main": "index.js",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",


### PR DESCRIPTION
The last version added `autofix` which is great BUT autofix also has it's own rules for `no-unused-vars`

Here I'm just fixing my matching the same rules from `@typescript-eslint` and applying them to `autofix`

Tested by building local package.
